### PR TITLE
Fix useCallback usage to have impact

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -4,7 +4,7 @@ import debounce from 'lodash.debounce';
 
 function App() {
   const [text, setText] = useState("Hello from react!");
-  const debouncedSetText = useCallback(debounce(setText, 100), []);
+  const debouncedSetText = useCallback(debounce(e => setText(e.target.value), 100), []);
 
   return (
     <>
@@ -12,7 +12,7 @@ function App() {
       <p>
         Generate a QR from text: 
         <br />
-        <input type="text" placeholder="Hello from react!" onChange={e => debouncedSetText(e.target.value)} />
+        <input type="text" placeholder="Hello from react!" onChange={debouncedSetText} />
       </p>
       <p>
         <QrImage text={text} />


### PR DESCRIPTION
The existing `useCallback` usage was redundant as the memoised function was then called as part of an anonymous function which would get recreated on every render since it wasn't in a `useCallback` itself.

I've changed it in this PR so that the event handler function will now have a stable identity and therefore the `useCallback` is preventing re-renders of the text box as per the intended design.

It's great having this example of using the new wasm tools with .net and react, thanks! We will hopefully use it soon